### PR TITLE
Bug Fixes for gentoo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+SRC = fetch.c
+CC = gcc
+
+all: afetch
+
+afetch:
+	$(CC) $(SRC) -o afetch
+clean:
+	rm aftech
+install:
+	cp ./afetch /usr/bin/afetch
+	chmod 711 /usr/bin/afetch
+
+.PHONY: clean all install

--- a/fetch.c
+++ b/fetch.c
@@ -58,7 +58,7 @@ char * pkg() {
 	else if (strncmp(distro, "Arch Linux", 10) == 0) { //something I'm doing seems to make 'Arch Linux' not work. I think it might be the strtok() in the os() function
 		return "pacman -Qq | wc -l"; }
 	else if (strncmp(distro, "Gentoo", 6) == 0) {
-		return "equery list \"*\""; } //not sure if this is how to do it on gentoo
+		return "equery list \"*\" | wc -l"; }
 	else if (strncmp(distro, "FreeBSD", 7) == 0) {
 		return "pkg list -i | wc -l"; }//I think this is the correct command? 
 

--- a/fetch.c
+++ b/fetch.c
@@ -41,7 +41,9 @@ char * os()
 	fclose(f);
 	str = strtok(dist, "NAME=\""); //if dist is Arch Linux, it seems to return rch Linux, so the next to lines fix it
 	if (strncmp(str, "rch Linux", 9) == 0) {
-		str = "Arch Linux"; }
+	        str = "Arch Linux"; }
+	else if (strncmp(str, "Gentoo\n", 7) == 0) { //Removing the newline at the end of the file
+	        str = "Gentoo"; }
 	return str;
 }
 


### PR DESCRIPTION
Removing the newline at the end of os-release and fixing the bug showing all the packages name