### PR TITLE
Fixing a terrible typo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ all: afetch
 afetch:
 	$(CC) $(SRC) -o afetch
 clean:
-	rm aftech
+	rm afetch
 install:
 	cp ./afetch /usr/bin/afetch
 	chmod 711 /usr/bin/afetch


### PR DESCRIPTION
I made an horrible typo that I just noticed now, I wrote "aftech" instead of "afetch" in the makefile