### PR TITLE
Using gwc instead of wc for FreeBSD

### DIFF
--- a/fetch.c
+++ b/fetch.c
@@ -99,7 +99,7 @@ Dist asciiart() {
    		info.dcol7=BRED"  '-_____-'  ";
    		info.dcol8=BRED"";
    		info.dcol1=BRED"";
-		info.getpkg="pkg info | wc -l";
+		info.getpkg="pkg info | gwc -l";
 		return info; }
 
 	else if (strncmp(dist, "Debian", 6)==0) {


### PR DESCRIPTION
So, if wc is used, it‘ll automatically add space before the number.  gwc doesn't add space before the number.

`% pkg info | wc -l`

     `593`
`% pkg info | gwc -l`
`593`