### PR TITLE
Fixing color bug

### DIFF
--- a/fetch.c
+++ b/fetch.c
@@ -167,5 +167,6 @@ int main(){
 		putchar(p); }
 	printf("%s", ascii.dcol8);
 	printf("\n");
+	printf("\e[0m"); // Reset terminal's colors
 	return 0;
 }


### PR DESCRIPTION
If you had a white $PS1 it showed in the distro color, now it's working correctly