### PR TITLE
DESTDIR and PREFIX support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,8 @@ afetch:
 clean:
 	rm afetch
 install:
-	mkdir -p ${DESTDIR}${PREFIX}
+	mkdir -p ${DESTDIR}${PREFIX}/bin
+	mkdir -p ${DESTDIR}${PREFIX}/share/man/man1
 	cp ./afetch ${DESTDIR}${PREFIX}/bin/afetch
 	chmod 711 ${DESTDIR}${PREFIX}/bin/afetch
 	cp ./afetch.1 ${DESTDIR}${PREFIX}/share/man/man1/afetch.1

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 SRC = fetch.c
 CC = cc
 CFLAGS = -O2
+PREFIX ?= /usr/local
 
 all: afetch
 
@@ -9,9 +10,9 @@ afetch:
 clean:
 	rm afetch
 install:
-	cp ./afetch /usr/local/bin/afetch
-	chmod 711 /usr/local/bin/afetch
-	cp ./afetch.1 /usr/local/share/man/man1/afetch.1
+	cp ./afetch ${DESTDIR}${PREFIX}/bin/afetch
+	chmod 711 ${DESTDIR}${PREFIX}/bin/afetch
+	cp ./afetch.1 ${DESTDIR}${PREFIX}/share/man/man1/afetch.1
 uninstall:
-	rm -f /usr/local/bin/afetch /usr/local/man/man1/afetch.1
+	rm -f ${DESTDIR}${PREFIX}/bin/afetch ${DESTDIR}${PREFIX}/man/man1/afetch.1
 .PHONY: clean all install

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ afetch:
 clean:
 	rm afetch
 install:
+	mkdir -p ${DESTDIR}${PREFIX}
 	cp ./afetch ${DESTDIR}${PREFIX}/bin/afetch
 	chmod 711 ${DESTDIR}${PREFIX}/bin/afetch
 	cp ./afetch.1 ${DESTDIR}${PREFIX}/share/man/man1/afetch.1


### PR DESCRIPTION
These changes allow users to choose where they want the program to be installed. Useful for package managers that require sandboxing such as gentoo's portage. These changes will default to `/usr/local/bin` for the installation directory as it was originally.