### PR TITLE
create man1 directory before installing man page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,8 @@ install:
 	chmod 711 ./afetch
 	cp ./afetch ${DESTDIR}${PREFIX}/bin
 	chmod 644 ./src/afetch.1
-	cp src/afetch.1 ${DESTDIR}${PREFIX}/share/man/man1 
+	mkdir -p ${DESTDIR}${PREFIX}/share/man/man1/
+	cp src/afetch.1 ${DESTDIR}${PREFIX}/share/man/man1/
 uninstall:
 	rm -f ${DESTDIR}${PREFIX}/bin/afetch ${DESTDIR}${PREFIX}/man/man1/afetch.1
 


### PR DESCRIPTION
When the `man1` directory does not exist, then the man page for afetch gets copied to `man1` file. It is necessary to create the `man1` directory before installing the man page.

In my case `man1` directory did not exist. And after installing afetch, I wasn't able to successfully install other programs from source because `man1` was a file instead of a directory