### PR TITLE
clang-format configuration created & applied to codebase

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,8 @@
+BasedOnStyle: LLVM
+IndentWidth: 8
+UseTab: AlignWithSpaces
+BreakBeforeBraces: Linux
+AllowShortIfStatementsOnASingleLine: false
+IndentCaseLabels: false
+ColumnLimit: 80
+AlignConsecutiveMacros: true

--- a/src/colour.h
+++ b/src/colour.h
@@ -1,20 +1,20 @@
-	/* BOLD COLOURS */
-#define BBLACK "\033[1;30m"
-#define BRED "\033[1;31m"
-#define BGREEN "\033[1;32m"
-#define BYELLOW "\033[1;33m"
-#define BBLUE "\033[1;34m"
+/* BOLD COLOURS */
+#define BBLACK   "\033[1;30m"
+#define BRED     "\033[1;31m"
+#define BGREEN   "\033[1;32m"
+#define BYELLOW  "\033[1;33m"
+#define BBLUE    "\033[1;34m"
 #define BMAGENTA "\033[1;35m"
-#define BCYAN "\033[1;36m"
-#define BWHITE "\033[1;37m"
-        /* NORMAL COLOURS */
-#define BLACK "\033[0;30m"
-#define RED "\033[0;31m"
-#define GREEN "\033[0;32m"
-#define YELLOW "\033[0;33m"
-#define BLUE "\033[0;34m"
+#define BCYAN    "\033[1;36m"
+#define BWHITE   "\033[1;37m"
+/* NORMAL COLOURS */
+#define BLACK   "\033[0;30m"
+#define RED     "\033[0;31m"
+#define GREEN   "\033[0;32m"
+#define YELLOW  "\033[0;33m"
+#define BLUE    "\033[0;34m"
 #define MAGENTA "\033[0;35m"
-#define CYAN "\033[0;36m"
-#define WHITE "\033[0;37m"
-	/* OTHER */
+#define CYAN    "\033[0;36m"
+#define WHITE   "\033[0;37m"
+/* OTHER */
 #define RESET "\033[0;m"

--- a/src/config.h
+++ b/src/config.h
@@ -1,16 +1,16 @@
-#define UserText    "   USER "  //
-#define OsText      "     OS "  //
-#define KernelText  " KERNEL "  //
-#define UptimeText  " UPTIME "  //
-#define ShellText   "  SHELL "  //
-#define PackageText "   PKGS "  //
+#define UserText    "   USER " //
+#define OsText      "     OS " //
+#define KernelText  " KERNEL " //
+#define UptimeText  " UPTIME " //
+#define ShellText   "  SHELL " //
+#define PackageText "   PKGS " //
 
 /* Those two options are mutually exclusive.
  * Either set one to 'true' or both to 'false'. */
 #define ForceLowerCase false
 #define ForceUpperCase false
 
-#define PrintColours false      //must be either 'true' or 'false'
+#define PrintColours    false /* must be either 'true' or 'false' */
 #define ColourCharacter "● "
 
 /* Some examples of things you may want to use for your ColourCharacter

--- a/src/fetch.c
+++ b/src/fetch.c
@@ -1,26 +1,27 @@
 #define _POSIX_C_SOURCE 200809L
 
+#include <pthread.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdbool.h>
 #include <string.h>
-#include <time.h>
-#include <pthread.h>
 #include <sys/utsname.h>
+#include <time.h>
 
 #include "colour.h"
 #include "config.h"
 
 struct dist {
-        char *col1, *col2, *col3, *col4, *col5, *col6, *col7, *col8;
-        char *getPkgCount;
+	char *col1, *col2, *col3, *col4, *col5, *col6, *col7, *col8;
+	char *getPkgCount;
 };
 struct dist info;
 char *username, *osname, *shellname, *pkgCount;
 char *krnlver;
 long uptimeH, uptimeM;
 
-void lowerCase(char *str) {
+void lowerCase(char *str)
+{
 	const int len = strlen(str);
 	int i;
 	for (i = 0; i < len; i += 1)
@@ -28,7 +29,8 @@ void lowerCase(char *str) {
 			str[i] += 'a' - 'A';
 }
 
-void upperCase(char *str) {
+void upperCase(char *str)
+{
 	const int len = strlen(str);
 	int i;
 	for (i = 0; i < len; i += 1)
@@ -36,10 +38,11 @@ void upperCase(char *str) {
 			str[i] += 'A' - 'a';
 }
 
-
-char *pipeRead(const char *exec){
+char *pipeRead(const char *exec)
+{
 	FILE *pipe = popen(exec, "r");
-	if (pipe == NULL) return NULL;
+	if (pipe == NULL)
+		return NULL;
 	char *returnVal = malloc(256);
 	const int scanf_return = fscanf(pipe, "%[^\n]s", returnVal);
 	if (scanf_return == EOF) {
@@ -50,332 +53,370 @@ char *pipeRead(const char *exec){
 	return returnVal;
 }
 
-
-void *kernel(){
+void *kernel()
+{
 	static struct utsname kernelData;
 	uname(&kernelData);
 	krnlver = kernelData.release;
 	return NULL;
 }
 
-void *uptime(){
+void *uptime()
+{
 	struct timespec time;
-	#ifdef CLOCK_BOOTTIME
-		clock_gettime(CLOCK_BOOTTIME, &time);
-		uptimeH = time.tv_sec / 3600;
-		uptimeM = (time.tv_sec / 60) - (time.tv_sec / 3600 * 60);
-	#elif CLOCK_UPTIME
-		clock_gettime(CLOCK_UPTIME, &time);
-		uptimeH = time.tv_sec / 3600;
-		uptimeM = (time.tv_sec / 60) - (time.tv_sec / 3600 * 60);
-	#elif __APPLE__ 
-		clock_gettime(CLOCK_MONOTONIC, &time);
-		uptimeH = time.tv_sec / 3600;
-		uptimeM = (time.tv_sec / 60) - (time.tv_sec / 3600 * 60);
-	#endif
+#ifdef CLOCK_BOOTTIME
+	clock_gettime(CLOCK_BOOTTIME, &time);
+	uptimeH = time.tv_sec / 3600;
+	uptimeM = (time.tv_sec / 60) - (time.tv_sec / 3600 * 60);
+#elif CLOCK_UPTIME
+	clock_gettime(CLOCK_UPTIME, &time);
+	uptimeH = time.tv_sec / 3600;
+	uptimeM = (time.tv_sec / 60) - (time.tv_sec / 3600 * 60);
+#elif __APPLE__
+	clock_gettime(CLOCK_MONOTONIC, &time);
+	uptimeH = time.tv_sec / 3600;
+	uptimeM = (time.tv_sec / 60) - (time.tv_sec / 3600 * 60);
+#endif
 	return NULL;
 }
 
-void *user(){
+void *user()
+{
 	username = getenv("USER");
-	
+
 	/* I'm not sure if lower case usernames
-	   are allowed in UNIX-like operating 
+	   are allowed in UNIX-like operating
 	   systems. I'll have to look into it */
-	//username = lowerCase(username);
-	
+	/* username = lowerCase(username); */
+
 	return NULL;
 }
 
-void *shell(){
+void *shell()
+{
 	char *shell = getenv("SHELL");
 	char *slash = strrchr(shell, '/');
 	if (slash) {
-		shell = slash + 1; }
+		shell = slash + 1;
+	}
 	shellname = shell;
 	return NULL;
 }
 
-
-void *os(){
+void *os()
+{
 	static struct utsname sysInfo;
 	uname(&sysInfo);
-	//start
-		/* This whole section could probably be rewritten - it seems 
-		   like a bit of a mess right now */
-	if (strncmp(sysInfo.sysname, "Linux", 5)==0) {
+	/* start */
+	/* This whole section could probably be rewritten - it seems
+	   like a bit of a mess right now */
+	if (strncmp(sysInfo.sysname, "Linux", 5) == 0) {
 		char *osContents = malloc(512);
 		char *newContents = malloc(512);
 		int line = 0;
 		FILE *f = fopen("/etc/os-release", "rt");
-		if (f == NULL || osContents == NULL) return "Linux";
-		// look through each line of /etc/os-release until we're on the NAME= line
+		if (f == NULL || osContents == NULL)
+			return "Linux";
+		/* look through each line of /etc/os-release until we're on the
+		 * NAME= line */
 		while (fgets(osContents, 512, f)) {
-			snprintf(newContents, 512, "%.*s", 511, osContents+4);
-			if (strncmp(newContents, "=", 1) == 0) break;
+			snprintf(newContents, 512, "%.*s", 511, osContents + 4);
+			if (strncmp(newContents, "=", 1) == 0)
+				break;
 			line++;
 		}
 		fclose(f);
 		free(osContents);
 		if (strncmp(newContents, "=", 1) == 0) {
 			int len = strlen(newContents);
-			for (int i = 0; i<len; i++){
-				if (newContents[i] == '\"' || newContents[i] == '=') {
-					for (int ii = 0; ii<len; ii++) newContents[ii] = newContents[ii+1];
-					newContents[strlen(newContents)-1] = '\0';
+			for (int i = 0; i < len; i++) {
+				if (newContents[i] == '\"' ||
+				    newContents[i] == '=') {
+					for (int ii = 0; ii < len; ii++)
+						newContents[ii] =
+						    newContents[ii + 1];
+					newContents[strlen(newContents) - 1] =
+					    '\0';
 				}
 			}
 		}
 		if (osname == NULL)
-    			osname = malloc(512);
+			osname = malloc(512);
 		strcpy(osname, newContents);
 		free(newContents);
-	//end
-		while (1){
+		/* end */
+		while (1) {
 			if (strncmp(osname, "Alpine Linux", 12) == 0) {
-				info.col1 = BBLUE"\n";
-				info.col2 = BBLUE"    /\\ /\\    ";
-				info.col3 = BBLUE"   /  \\  \\   ";
-				info.col4 = BBLUE"  /    \\  \\  ";
-				info.col5 = BBLUE" /      \\  \\ ";
-				info.col6 = BBLUE"/        \\  \\";
-				info.col7 = BBLUE"          \\  ";
-				info.col8 = BBLUE"";
+				info.col1 = BBLUE "\n";
+				info.col2 = BBLUE "    /\\ /\\    ";
+				info.col3 = BBLUE "   /  \\  \\   ";
+				info.col4 = BBLUE "  /    \\  \\  ";
+				info.col5 = BBLUE " /      \\  \\ ";
+				info.col6 = BBLUE "/        \\  \\";
+				info.col7 = BBLUE "          \\  ";
+				info.col8 = BBLUE "";
 				info.getPkgCount = "apk info | wc -l";
 				break;
 			} else if (strncmp(osname, "Arch Linux", 10) == 0) {
-				info.col1 = BCYAN"";
-				info.col2 = BCYAN"      /\\      ";
-				info.col3 = BCYAN"     /  \\     ";
-				info.col4 = BCYAN"    /\\   \\    ";
-				info.col5 = BCYAN"   /      \\   ";
-				info.col6 = BCYAN"  /   ,,   \\  ";
-				info.col7 = BCYAN" /   |  |  -\\ ";
-				info.col8 = BCYAN"/_-''    ''-_\\\n";
+				info.col1 = BCYAN "";
+				info.col2 = BCYAN "      /\\      ";
+				info.col3 = BCYAN "     /  \\     ";
+				info.col4 = BCYAN "    /\\   \\    ";
+				info.col5 = BCYAN "   /      \\   ";
+				info.col6 = BCYAN "  /   ,,   \\  ";
+				info.col7 = BCYAN " /   |  |  -\\ ";
+				info.col8 = BCYAN "/_-''    ''-_\\\n";
 				info.getPkgCount = "pacman -Qq | wc -l";
 				break;
-			} else if (strncmp(osname, "Arch bang Linux", 15) == 0) {
-				info.col1 = BCYAN"          ____\n";
-				info.col2 = BCYAN"      /\\ /   /";
-				info.col3 = BCYAN"     /  /   / ";
-				info.col4 = BCYAN"    /   / /   ";
-				info.col5 = BCYAN"   /   /_/\\   ";
-				info.col6 = BCYAN"  /   __   \\  ";
-				info.col7 = BCYAN" /   /_/\\   \\ ";
-				info.col8 = BCYAN"/_-''    ''-_\\\n";
+			} else if (strncmp(osname, "Arch bang Linux", 15) ==
+			           0) {
+				info.col1 = BCYAN "          ____\n";
+				info.col2 = BCYAN "      /\\ /   /";
+				info.col3 = BCYAN "     /  /   / ";
+				info.col4 = BCYAN "    /   / /   ";
+				info.col5 = BCYAN "   /   /_/\\   ";
+				info.col6 = BCYAN "  /   __   \\  ";
+				info.col7 = BCYAN " /   /_/\\   \\ ";
+				info.col8 = BCYAN "/_-''    ''-_\\\n";
 				info.getPkgCount = "pacman -Qq | wc -l";
 				break;
 			} else if (strncmp(osname, "ArcoLinux", 9) == 0) {
-				info.col1 = BBLUE"";
-				info.col2 = BBLUE"      /\\      ";
-				info.col3 = BBLUE"     /  \\     ";
-				info.col4 = BBLUE"    / /\\ \\    ";
-				info.col5 = BBLUE"   / /  \\ \\   ";
-				info.col6 = BBLUE"  / /    \\ \\  ";
-				info.col7 = BBLUE" / / _____\\ \\ ";
-				info.col8 = BBLUE"/_/  `----.\\_\\\n";
+				info.col1 = BBLUE "";
+				info.col2 = BBLUE "      /\\      ";
+				info.col3 = BBLUE "     /  \\     ";
+				info.col4 = BBLUE "    / /\\ \\    ";
+				info.col5 = BBLUE "   / /  \\ \\   ";
+				info.col6 = BBLUE "  / /    \\ \\  ";
+				info.col7 = BBLUE " / / _____\\ \\ ";
+				info.col8 = BBLUE "/_/  `----.\\_\\\n";
 				info.getPkgCount = "pacman -Qq | wc -l";
 				break;
 			} else if (strncmp(osname, "Artix Linux", 11) == 0) {
-				info.col1 = BCYAN"";
-				info.col2 = BCYAN"      /\\      ";
-				info.col3 = BCYAN"     /  \\     ";
-				info.col4 = BCYAN"    /`'.,\\    ";
-				info.col5 = BCYAN"   /     ',   ";
-				info.col6 = BCYAN"  /      ,`\\  ";
-				info.col7 = BCYAN" /   ,.'`.  \\ ";
-				info.col8 = BCYAN"/.,'`     `'.\\\n";
+				info.col1 = BCYAN "";
+				info.col2 = BCYAN "      /\\      ";
+				info.col3 = BCYAN "     /  \\     ";
+				info.col4 = BCYAN "    /`'.,\\    ";
+				info.col5 = BCYAN "   /     ',   ";
+				info.col6 = BCYAN "  /      ,`\\  ";
+				info.col7 = BCYAN " /   ,.'`.  \\ ";
+				info.col8 = BCYAN "/.,'`     `'.\\\n";
 				info.getPkgCount = "pacman -Qq | wc -l";
 				break;
 			} else if (strncmp(osname, "Deepin", 6) == 0) {
-				info.col1 = BRED"\n";
-				info.col2 = BRED"";
-				info.col3 = BRED"";
-				info.col4 = BRED"";
-				info.col5 = BRED"";
-				info.col6 = BRED"";
-				info.col7 = BRED"";
-				info.col8 = BRED"";
-				info.getPkgCount = "dpkg -l | tail -n+6 | wc -l";
+				info.col1 = BRED "\n";
+				info.col2 = BRED "";
+				info.col3 = BRED "";
+				info.col4 = BRED "";
+				info.col5 = BRED "";
+				info.col6 = BRED "";
+				info.col7 = BRED "";
+				info.col8 = BRED "";
+				info.getPkgCount =
+				    "dpkg -l | tail -n+6 | wc -l";
 				break;
-			} else if (strncmp(osname, "Debian GNU/Linux", 16) == 0) {
-				info.col1 = BRED"  _____\n";
-				info.col2 = BRED" /  __ \\ ";
-				info.col3 = BRED"|  /    |";
-				info.col4 = BRED"|  \\___- ";
-				info.col5 = BRED"-_       ";
-				info.col6 = BRED"  --_    ";
-				info.col7 = BRED"         ";
-				info.col8 = BRED"";
-				info.getPkgCount = "dpkg -l | tail -n+6 | wc -l";
+			} else if (strncmp(osname, "Debian GNU/Linux", 16) ==
+			           0) {
+				info.col1 = BRED "  _____\n";
+				info.col2 = BRED " /  __ \\ ";
+				info.col3 = BRED "|  /    |";
+				info.col4 = BRED "|  \\___- ";
+				info.col5 = BRED "-_       ";
+				info.col6 = BRED "  --_    ";
+				info.col7 = BRED "         ";
+				info.col8 = BRED "";
+				info.getPkgCount =
+				    "dpkg -l | tail -n+6 | wc -l";
 				break;
 			} else if (strncmp(osname, "elementary OS", 12) == 0) {
-				info.col1 = BCYAN"";
-				info.col2 = BCYAN"  _______  ";
-				info.col3 = BCYAN" / ____  \\ ";
-				info.col4 = BCYAN"/  |  /  /\\";
-				info.col5 = BCYAN"|__\\ /  / |";
-				info.col6 = BCYAN"\\   /__/  /";
-				info.col7 = BCYAN" \\_______/ ";
-				info.col8 = BCYAN"";
-				info.getPkgCount = "dpkg -l | tail -n+6 | wc -l";
+				info.col1 = BCYAN "";
+				info.col2 = BCYAN "  _______  ";
+				info.col3 = BCYAN " / ____  \\ ";
+				info.col4 = BCYAN "/  |  /  /\\";
+				info.col5 = BCYAN "|__\\ /  / |";
+				info.col6 = BCYAN "\\   /__/  /";
+				info.col7 = BCYAN " \\_______/ ";
+				info.col8 = BCYAN "";
+				info.getPkgCount =
+				    "dpkg -l | tail -n+6 | wc -l";
 				break;
 			} else if (strncmp(osname, "EndeavourOS", 11) == 0) {
-				info.col1 = BCYAN"";
-				info.col2 = BRED"      /"BBLUE"\\     "BCYAN;
-				info.col3 = BRED"    /"BBLUE"/  \\"BCYAN"\\   "BCYAN;
-				info.col4 = BRED"   /"BBLUE"/    \\ "BCYAN"\\ "BCYAN;
-				info.col5 = BRED" / "BBLUE"/     _) "BCYAN")"BCYAN;
-				info.col6 = BRED"/_"BBLUE"/___-- "BCYAN"__- "BCYAN;
-				info.col7 = BCYAN" /____--     "BCYAN;
-				info.col8 = BCYAN"";
+				info.col1 = BCYAN "";
+				info.col2 =
+				    BRED "      /" BBLUE "\\     " BCYAN;
+				info.col3 = BRED "    /" BBLUE "/  \\" BCYAN
+						 "\\   " BCYAN;
+				info.col4 = BRED "   /" BBLUE "/    \\ " BCYAN
+						 "\\ " BCYAN;
+				info.col5 = BRED " / " BBLUE "/     _) " BCYAN
+						 ")" BCYAN;
+				info.col6 = BRED "/_" BBLUE "/___-- " BCYAN
+						 "__- " BCYAN;
+				info.col7 = BCYAN " /____--     " BCYAN;
+				info.col8 = BCYAN "";
 				info.getPkgCount = "pacman -Qq | wc -l";
 				break;
 			} else if (strncmp(osname, "Fedora", 6) == 0) {
-				info.col1 = BWHITE"      _____\n"BBLUE;
-				info.col2 = BWHITE"     /   __)"BBLUE"\\ ";
-				info.col3 = BWHITE"     |  /  "BBLUE"\\ \\";
-				info.col4 = BWHITE"  ___|  |"BBLUE"__/ /";
-				info.col5 = BBLUE" / "BWHITE"(_    _)"BBLUE"_/ ";
-				info.col6 = BBLUE"/ /  "BWHITE"|  |     "BBLUE;
-				info.col7 = BBLUE"\\ \\"BWHITE"__/  |     "BBLUE;
-				info.col8 = BBLUE" \\"BWHITE"(_____/"BBLUE;
-				info.getPkgCount = "[[ $(which sqlite3 2>/dev/null) && $? -ne 1 ]] && (sqlite3 /var/lib/rpm/rpmdb.sqlite \"select * from Name\"|wc -l) || rpm -qa | wc -l";
+				info.col1 = BWHITE "      _____\n" BBLUE;
+				info.col2 = BWHITE "     /   __)" BBLUE "\\ ";
+				info.col3 = BWHITE "     |  /  " BBLUE "\\ \\";
+				info.col4 = BWHITE "  ___|  |" BBLUE "__/ /";
+				info.col5 =
+				    BBLUE " / " BWHITE "(_    _)" BBLUE "_/ ";
+				info.col6 =
+				    BBLUE "/ /  " BWHITE "|  |     " BBLUE;
+				info.col7 =
+				    BBLUE "\\ \\" BWHITE "__/  |     " BBLUE;
+				info.col8 = BBLUE " \\" BWHITE "(_____/" BBLUE;
+				info.getPkgCount =
+				    "[[ $(which sqlite3 2>/dev/null) && $? -ne "
+				    "1 ]] && (sqlite3 "
+				    "/var/lib/rpm/rpmdb.sqlite \"select * from "
+				    "Name\"|wc -l) || rpm -qa | wc -l";
 				break;
 			} else if (strncmp(osname, "Gentoo", 6) == 0) {
-				info.col1 = BMAGENTA"   _-----_ \n";
-				info.col2 = BMAGENTA"  (       \\  ";
-				info.col3 = BMAGENTA"  \\    0   \\ ";
-				info.col4 = BMAGENTA"   \\        )";
-				info.col5 = BMAGENTA"   /      _/ ";
-				info.col6 = BMAGENTA"  (     _-   ";
-				info.col7 = BMAGENTA"  \\____-     ";
-				info.col8 = BWHITE"\n";
+				info.col1 = BMAGENTA "   _-----_ \n";
+				info.col2 = BMAGENTA "  (       \\  ";
+				info.col3 = BMAGENTA "  \\    0   \\ ";
+				info.col4 = BMAGENTA "   \\        )";
+				info.col5 = BMAGENTA "   /      _/ ";
+				info.col6 = BMAGENTA "  (     _-   ";
+				info.col7 = BMAGENTA "  \\____-     ";
+				info.col8 = BWHITE "\n";
 				info.getPkgCount = "qlist -IRv | wc -l";
 				break;
 			} else if (strncmp(osname, "KDE neon", 8) == 0) {
-				info.col1 = BGREEN"";
-				info.col2 = BGREEN"            ";
-				info.col3 = BGREEN"     --- _  ";
-				info.col4 = BGREEN"  /  ---  \\ ";
-				info.col5 = BGREEN" |  |   |  |";
-				info.col6 = BGREEN"  \\  --- _/ ";
-				info.col7 = BGREEN"     ---    ";
-				info.col8 = BGREEN"";
-				info.getPkgCount = "dpkg -l | tail -n+6 | wc -l";
+				info.col1 = BGREEN "";
+				info.col2 = BGREEN "            ";
+				info.col3 = BGREEN "     --- _  ";
+				info.col4 = BGREEN "  /  ---  \\ ";
+				info.col5 = BGREEN " |  |   |  |";
+				info.col6 = BGREEN "  \\  --- _/ ";
+				info.col7 = BGREEN "     ---    ";
+				info.col8 = BGREEN "";
+				info.getPkgCount =
+				    "dpkg -l | tail -n+6 | wc -l";
 				break;
 			} else if (strncmp(osname, "Manjaro", 7) == 0) {
-				info.col1 = BGREEN" ________  __ \n";
-				info.col2 = BGREEN"|       | |  |";
-				info.col3 = BGREEN"|   ____| |  |";
-				info.col4 = BGREEN"|  |  __  |  |";
-				info.col5 = BGREEN"|  | |  | |  |";
-				info.col6 = BGREEN"|  | |  | |  |";
-				info.col7 = BGREEN"|  | |  | |  |";
-				info.col8 = BGREEN"|__| |__| |__|\n";
+				info.col1 = BGREEN " ________  __ \n";
+				info.col2 = BGREEN "|       | |  |";
+				info.col3 = BGREEN "|   ____| |  |";
+				info.col4 = BGREEN "|  |  __  |  |";
+				info.col5 = BGREEN "|  | |  | |  |";
+				info.col6 = BGREEN "|  | |  | |  |";
+				info.col7 = BGREEN "|  | |  | |  |";
+				info.col8 = BGREEN "|__| |__| |__|\n";
 				info.getPkgCount = "pacman -Qq | wc -l";
 				break;
 			} else if (strncmp(osname, "NixOS", 5) == 0) {
-				info.col1 = BMAGENTA"            \n";
-				info.col2 = BMAGENTA"  \\\\  \\\\ //     ";
-				info.col3 = BMAGENTA" ==\\\\__\\\\/ //   ";
-				info.col4 = BMAGENTA"   //   \\\\//    ";
-				info.col5 = BMAGENTA"==//     //==   ";
-				info.col6 = BMAGENTA" //\\\\___//      ";
-				info.col7 = BMAGENTA"// /\\\\  \\\\==    ";
-				info.col8 = BMAGENTA"  // \\\\  \\\\     ";
-				info.getPkgCount = "nix-store -q --requisites /run/current-system/sw | wc -l";
+				info.col1 = BMAGENTA "            \n";
+				info.col2 = BMAGENTA "  \\\\  \\\\ //     ";
+				info.col3 = BMAGENTA " ==\\\\__\\\\/ //   ";
+				info.col4 = BMAGENTA "   //   \\\\//    ";
+				info.col5 = BMAGENTA "==//     //==   ";
+				info.col6 = BMAGENTA " //\\\\___//      ";
+				info.col7 = BMAGENTA "// /\\\\  \\\\==    ";
+				info.col8 = BMAGENTA "  // \\\\  \\\\     ";
+				info.getPkgCount =
+				    "nix-store -q --requisites "
+				    "/run/current-system/sw | wc -l";
 				break;
-			} else if (strncmp(osname, "openSUSE Leap", 10) == 0 || strncmp(osname, "openSUSE Tumbleweed", 19) == 0) {
-				info.col1 = BGREEN"  _______\n";
-				info.col2 = BGREEN"__|   __ \\ ";
-				info.col3 = BGREEN"     / .\\ \\";
-				info.col4 = BGREEN"     \\__/ |";
-				info.col5 = BGREEN"   _______|";
-				info.col6 = BGREEN"   \\_______";
-				info.col7 = BGREEN"__________/";
-				info.col8 = BGREEN"";
+			} else if (strncmp(osname, "openSUSE Leap", 10) == 0 ||
+			           strncmp(osname, "openSUSE Tumbleweed", 19) ==
+			               0) {
+				info.col1 = BGREEN "  _______\n";
+				info.col2 = BGREEN "__|   __ \\ ";
+				info.col3 = BGREEN "     / .\\ \\";
+				info.col4 = BGREEN "     \\__/ |";
+				info.col5 = BGREEN "   _______|";
+				info.col6 = BGREEN "   \\_______";
+				info.col7 = BGREEN "__________/";
+				info.col8 = BGREEN "";
 				info.getPkgCount = "rpm -qa | wc -l";
 				break;
 			} else if (strncmp(osname, "Parabola", 8) == 0) {
-				info.col1 = BMAGENTA"";
-				info.col2 = BMAGENTA"  __ __ __  _  ";
-				info.col3 = BMAGENTA".`_//_//_/ / `.";
-				info.col4 = BMAGENTA"          /  .`";
-				info.col5 = BMAGENTA"         / .`  ";
-				info.col6 = BMAGENTA"        /.`    ";
-				info.col7 = BMAGENTA"       /`      ";
-				info.col8 = BMAGENTA"";
+				info.col1 = BMAGENTA "";
+				info.col2 = BMAGENTA "  __ __ __  _  ";
+				info.col3 = BMAGENTA ".`_//_//_/ / `.";
+				info.col4 = BMAGENTA "          /  .`";
+				info.col5 = BMAGENTA "         / .`  ";
+				info.col6 = BMAGENTA "        /.`    ";
+				info.col7 = BMAGENTA "       /`      ";
+				info.col8 = BMAGENTA "";
 				info.getPkgCount = "pacman -Qq | wc -l";
 				break;
 			} else if (strncmp(osname, "Pop!_OS", 7) == 0) {
-				info.col1 = BCYAN"______\n";
-				info.col2 = BCYAN"\\   _ \\        __";
-				info.col3 = BCYAN" \\ \\ \\ \\      / /";
-				info.col4 = BCYAN"  \\ \\_\\ \\    / / ";
-				info.col5 = BCYAN"   \\  ___\\  /_/  ";
-				info.col6 = BCYAN"    \\ \\    _     ";
-				info.col7 = BCYAN"   __\\_\\__(_)_   ";
-				info.col8 = BCYAN"  (___________)";
-				info.getPkgCount = "dpkg -l | tail -n+6 | wc -l";
+				info.col1 = BCYAN "______\n";
+				info.col2 = BCYAN "\\   _ \\        __";
+				info.col3 = BCYAN " \\ \\ \\ \\      / /";
+				info.col4 = BCYAN "  \\ \\_\\ \\    / / ";
+				info.col5 = BCYAN "   \\  ___\\  /_/  ";
+				info.col6 = BCYAN "    \\ \\    _     ";
+				info.col7 = BCYAN "   __\\_\\__(_)_   ";
+				info.col8 = BCYAN "  (___________)";
+				info.getPkgCount =
+				    "dpkg -l | tail -n+6 | wc -l";
 				break;
 			} else if (strncmp(osname, "Slackware", 10) == 0) {
-				info.col1 = BBLUE"   ________\n";
-				info.col2 = BBLUE"  /  ______| ";
-				info.col3 = BBLUE"  | |______  ";
-				info.col4 = BBLUE"  \\______  \\ ";
-				info.col5 = BBLUE"   ______| | ";
-				info.col6 = BBLUE"| |________/ ";
-				info.col7 = BBLUE"|____________";
-				info.col8 = BBLUE"";
-				info.getPkgCount = "ls /var/log/packages | wc -l";
+				info.col1 = BBLUE "   ________\n";
+				info.col2 = BBLUE "  /  ______| ";
+				info.col3 = BBLUE "  | |______  ";
+				info.col4 = BBLUE "  \\______  \\ ";
+				info.col5 = BBLUE "   ______| | ";
+				info.col6 = BBLUE "| |________/ ";
+				info.col7 = BBLUE "|____________";
+				info.col8 = BBLUE "";
+				info.getPkgCount =
+				    "ls /var/log/packages | wc -l";
 				break;
 			} else if (strncmp(osname, "Solus", 5) == 0) {
-				info.col1 = BMAGENTA"    __________\n";
-				info.col2 = BMAGENTA"   /          \\   ";
-				info.col3 = BMAGENTA"  /   /\\ \\     \\  ";
-				info.col4 = BMAGENTA" /   /  \\ \\     \\ ";
-				info.col5 = BMAGENTA"|   /    \\ \\     |";
-				info.col6 = BMAGENTA" \\--------------/ ";
-				info.col7 = BMAGENTA"  \\------------/  ";
-				info.col8 = BMAGENTA"   \\----------/";
-				info.getPkgCount = "ls /var/lib/eopkg/package/ | wc -l";
+				info.col1 = BMAGENTA "    __________\n";
+				info.col2 = BMAGENTA "   /          \\   ";
+				info.col3 = BMAGENTA "  /   /\\ \\     \\  ";
+				info.col4 = BMAGENTA " /   /  \\ \\     \\ ";
+				info.col5 = BMAGENTA "|   /    \\ \\     |";
+				info.col6 = BMAGENTA " \\--------------/ ";
+				info.col7 = BMAGENTA "  \\------------/  ";
+				info.col8 = BMAGENTA "   \\----------/";
+				info.getPkgCount =
+				    "ls /var/lib/eopkg/package/ | wc -l";
 				break;
 			} else if (strncmp(osname, "Ubuntu", 6) == 0) {
-				info.col1 = BRED"";
-				info.col2 = BRED"         _  ";
-				info.col3 = BRED"     ---(_) ";
-				info.col4 = BRED" _/  ---  \\ ";
-				info.col5 = BRED"(_) |   |   ";
-				info.col6 = BRED"  \\  --- _/ ";
-				info.col7 = BRED"     ---(_) ";
-				info.col8 = BRED"";
-				info.getPkgCount = "dpkg -l | tail -n+6 | wc -l";
+				info.col1 = BRED "";
+				info.col2 = BRED "         _  ";
+				info.col3 = BRED "     ---(_) ";
+				info.col4 = BRED " _/  ---  \\ ";
+				info.col5 = BRED "(_) |   |   ";
+				info.col6 = BRED "  \\  --- _/ ";
+				info.col7 = BRED "     ---(_) ";
+				info.col8 = BRED "";
+				info.getPkgCount =
+				    "dpkg -l | tail -n+6 | wc -l";
 				break;
 			} else if (strncmp(osname, "void", 4) == 0) {
-				info.col1 = BGREEN"     _______\n";
-				info.col2 = BGREEN"  _ \\______ - ";
-				info.col3 = BGREEN" | \\  ___  \\ |";
-				info.col4 = BGREEN" | | /   \\ | |";
-				info.col5 = BGREEN" | | \\___/ | |";
-				info.col6 = BGREEN" | \\______ \\_|";
+				info.col1 = BGREEN "     _______\n";
+				info.col2 = BGREEN "  _ \\______ - ";
+				info.col3 = BGREEN " | \\  ___  \\ |";
+				info.col4 = BGREEN " | | /   \\ | |";
+				info.col5 = BGREEN " | | \\___/ | |";
+				info.col6 = BGREEN " | \\______ \\_|";
 				info.col7 = BGREEN "  -_______\\   ";
 				info.col8 = "";
 				info.getPkgCount = "xbps-query -l | wc -l";
-				break; }
-	}
+				break;
+			}
+		}
 
-	} else if (strncmp(sysInfo.sysname, "Darwin", 6)==0) {
-		info.col1 = ""BYELLOW;
-		info.col2 = BGREEN   "          .:'   "BYELLOW;
-		info.col3 = BGREEN   "      __ :'__   "BYELLOW;
-		info.col4 = BYELLOW  "   .'`__`-'__``."BYELLOW;
-		info.col5 = BRED     "  :__________.-'"BYELLOW;
-		info.col6 = BRED     "  :_________:   "BYELLOW;
-		info.col7 = BMAGENTA "   :_________`-;"BYELLOW;
-		info.col8 = BBLUE    "    `.__.-.__.' "BYELLOW;
-		info.getPkgCount = "ls /usr/local/Cellar/* | grep ':' | wc -l | xargs";
-
+	} else if (strncmp(sysInfo.sysname, "Darwin", 6) == 0) {
+		info.col1 = "" BYELLOW;
+		info.col2 = BGREEN "          .:'   " BYELLOW;
+		info.col3 = BGREEN "      __ :'__   " BYELLOW;
+		info.col4 = BYELLOW "   .'`__`-'__``." BYELLOW;
+		info.col5 = BRED "  :__________.-'" BYELLOW;
+		info.col6 = BRED "  :_________:   " BYELLOW;
+		info.col7 = BMAGENTA "   :_________`-;" BYELLOW;
+		info.col8 = BBLUE "    `.__.-.__.' " BYELLOW;
+		info.getPkgCount =
+		    "ls /usr/local/Cellar/* | grep ':' | wc -l | xargs";
 
 		char *macVer = malloc(64);
 		strcpy(macVer, "macOS ");
@@ -385,69 +426,74 @@ void *os(){
 		free(productVer);
 		osname = macVer;
 		free(macVer);
-	} else if (strncmp(sysInfo.sysname, "FreeBSD", 7)==0){
-		info.col1 = BRED"";
-        info.col2 = BRED"/\\,-'''''-,/\\";
-        info.col3 = BRED"\\_)       (_/";
-        info.col4 = BRED"|           |";
-        info.col5 = BRED"|           |";
-        info.col6 = BRED" ;         ; ";
-        info.col7 = BRED"  '-_____-'  ";
-        info.col8 = BRED"";
-        info.getPkgCount = "pkg info | wc -l | tr -d ' '";
+	} else if (strncmp(sysInfo.sysname, "FreeBSD", 7) == 0) {
+		info.col1 = BRED "";
+		info.col2 = BRED "/\\,-'''''-,/\\";
+		info.col3 = BRED "\\_)       (_/";
+		info.col4 = BRED "|           |";
+		info.col5 = BRED "|           |";
+		info.col6 = BRED " ;         ; ";
+		info.col7 = BRED "  '-_____-'  ";
+		info.col8 = BRED "";
+		info.getPkgCount = "pkg info | wc -l | tr -d ' '";
 		osname = sysInfo.sysname;
-	} else if (strncmp(sysInfo.sysname, "OpenBSD", 7)==0) {
-		info.col1 = BYELLOW"      _____    \n";
-        info.col2 = BYELLOW"    \\-     -/  ";
-        info.col3 = BYELLOW" \\_/         \\ ";
-        info.col4 = BYELLOW" |        "BWHITE"O O"BYELLOW" |";
-        info.col5 = BYELLOW" |_  <   )  3 )";
-        info.col6 = BYELLOW" / \\         / ";
-        info.col7 = BYELLOW"    /-_____-\\  ";
-        info.col8 = BYELLOW"";
-        info.getPkgCount = "/bin/ls -1 /var/db/pkg/ | wc -l | tr -d ' '";
+	} else if (strncmp(sysInfo.sysname, "OpenBSD", 7) == 0) {
+		info.col1 = BYELLOW "      _____    \n";
+		info.col2 = BYELLOW "    \\-     -/  ";
+		info.col3 = BYELLOW " \\_/         \\ ";
+		info.col4 = BYELLOW " |        " BWHITE "O O" BYELLOW " |";
+		info.col5 = BYELLOW " |_  <   )  3 )";
+		info.col6 = BYELLOW " / \\         / ";
+		info.col7 = BYELLOW "    /-_____-\\  ";
+		info.col8 = BYELLOW "";
+		info.getPkgCount =
+		    "/bin/ls -1 /var/db/pkg/ | wc -l | tr -d ' '";
 		osname = sysInfo.sysname;
-	} else if (strncmp(sysInfo.sysname, "NetBSD", 6)==0) {
+	} else if (strncmp(sysInfo.sysname, "NetBSD", 6) == 0) {
 
 	} else {
-		info.col1 = BWHITE"     ___   \n";
-        info.col2 = BWHITE" ___/   \\___ ";
-        info.col3 = BWHITE"/   '---'   \\";
-        info.col4 = BWHITE"'--_______--'";
-        info.col5 = BWHITE"     / \\     ";
-        info.col6 = BWHITE"    /   \\    ";
-        info.col7 = BWHITE"   /     \\   ";
-        info.col8 = BWHITE"";
-        info.getPkgCount = "echo unsupported";
+		info.col1 = BWHITE "     ___   \n";
+		info.col2 = BWHITE " ___/   \\___ ";
+		info.col3 = BWHITE "/   '---'   \\";
+		info.col4 = BWHITE "'--_______--'";
+		info.col5 = BWHITE "     / \\     ";
+		info.col6 = BWHITE "    /   \\    ";
+		info.col7 = BWHITE "   /     \\   ";
+		info.col8 = BWHITE "";
+		info.getPkgCount = "echo unsupported";
 	}
 	pkgCount = pipeRead(info.getPkgCount);
 
-	if (ForceLowerCase) lowerCase(osname);
-	if (ForceUpperCase) upperCase(osname);
+	if (ForceLowerCase)
+		lowerCase(osname);
+	if (ForceUpperCase)
+		upperCase(osname);
 	return NULL;
 }
 
-void *colourDraw(){
+void *colourDraw()
+{
 	if (PrintColours == false)
 		return NULL;
 
 	printf("    ");
-	for (int i = 30; i<38; i++){
-		printf("\033[0;%dm %s", i, ColourCharacter); } //print regular term colours
+	for (int i = 30; i < 38; i++) {
+		printf("\033[0;%dm %s", i, ColourCharacter);
+	} // print regular term colours
 	printf("\n    ");
-	for (int i = 30; i<38; i++){
-		printf("\033[1;%dm %s", i, ColourCharacter); }
+	for (int i = 30; i < 38; i++) {
+		printf("\033[1;%dm %s", i, ColourCharacter);
+	}
 
 	printf("\n");
 	return NULL;
 }
 
-
-int main(){
+int main()
+{
 	struct utsname sysInfo;
 	uname(&sysInfo);
 	pthread_t threads[6];
-
 
 	pthread_create(&threads[0], NULL, user, NULL);
 	pthread_create(&threads[1], NULL, os, NULL);
@@ -456,17 +502,19 @@ int main(){
 	pthread_create(&threads[4], NULL, shell, NULL);
 
 	pthread_join(threads[0], NULL);
-	pthread_join(threads[1], NULL); //os function must be run to get info.col1
+	/* os function must be run to get info.col1 */
+	pthread_join(threads[1], NULL);
 	printf("%s", info.col1);
-	printf("%s    %s%s%s\n", info.col2, UserText ,WHITE, username);
-	printf("%s    %s%s%s\n", info.col3, OsText , WHITE, osname);
+	printf("%s    %s%s%s\n", info.col2, UserText, WHITE, username);
+	printf("%s    %s%s%s\n", info.col3, OsText, WHITE, osname);
 	pthread_join(threads[2], NULL);
-	printf("%s    %s%s%s\n", info.col4,KernelText,WHITE, krnlver);
+	printf("%s    %s%s%s\n", info.col4, KernelText, WHITE, krnlver);
 	pthread_join(threads[3], NULL);
-	printf("%s    %s%s%ldh %ldm\n", info.col5,UptimeText,WHITE, uptimeH, uptimeM);
+	printf("%s    %s%s%ldh %ldm\n", info.col5, UptimeText, WHITE, uptimeH,
+	       uptimeM);
 	pthread_join(threads[4], NULL);
-	printf("%s    %s%s%s\n", info.col6,ShellText,WHITE, shellname);
-	printf("%s    %s%s%s\n", info.col7,PackageText ,WHITE, pkgCount);
+	printf("%s    %s%s%s\n", info.col6, ShellText, WHITE, shellname);
+	printf("%s    %s%s%s\n", info.col7, PackageText, WHITE, pkgCount);
 	printf("%s\n", info.col8);
 
 	pthread_create(&threads[5], NULL, colourDraw, NULL);


### PR DESCRIPTION
Using a tool such as clang-format can help to adopt a consistant styling througout the codebase. The command I ran to beautify the existing codebase is:
```sh
clang-format -style=file -i src/*
```
It uses the configuration settings you can find in the `.clang-format` file.