### PR TITLE
Faster Alpine Linux package count

### DIFF
--- a/src/fetch.c
+++ b/src/fetch.c
@@ -155,7 +155,8 @@ void *os()
 				info.col6 = BBLUE "/        \\  \\";
 				info.col7 = BBLUE "          \\  ";
 				info.col8 = BBLUE "";
-				info.getPkgCount = "apk info | wc -l";
+				info.getPkgCount =
+				    "grep 'P:' /lib/apk/db/installed | wc -l";
 				break;
 			} else if (strncmp(osname, "Arch Linux", 10) == 0) {
 				info.col1 = BCYAN "";


### PR DESCRIPTION
My system has 926 packages installed right now, here are some stats before and after my change.
Previous command:
```
> time afetch

    /\ /\           USER kdx
   /  \  \            OS Alpine Linux
  /    \  \       KERNEL 5.10.27-0-lts
 /      \  \      UPTIME 0h 30m
/        \  \      SHELL fish
          \         PKGS 926


________________________________________________________
Executed in  371.04 millis    fish           external
   usr time  333.39 millis  601.00 micros  332.79 millis
   sys time   39.03 millis   80.00 micros   38.95 millis
```

New command:
```
> time ./afetch

    /\ /\           USER kdx
   /  \  \            OS Alpine Linux
  /    \  \       KERNEL 5.10.27-0-lts
 /      \  \      UPTIME 0h 31m
/        \  \      SHELL fish
          \         PKGS 926


________________________________________________________
Executed in   15.22 millis    fish           external
   usr time   15.35 millis    0.00 micros   15.35 millis
   sys time    1.65 millis  705.00 micros    0.94 millis
```