### PR TITLE
Improved Void's Logo and Made Installation Simpler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ debug:
 clean:
 	rm -rf afetch afetch.dSYM afetch-debug afetch-debug.dSYM
 
-install:
+install: afetch
 	mkdir -p ${DESTDIR}${PREFIX}/bin
 	cp afetch ${DESTDIR}${PREFIX}/bin
 	chmod 711 ${DESTDIR}${PREFIX}/bin/afetch

--- a/src/colour.h
+++ b/src/colour.h
@@ -18,3 +18,4 @@
 #define WHITE   "\033[0;37m"
 /* OTHER */
 #define RESET "\033[0;m"
+#define BITAL  "\033[1;3m" 

--- a/src/colour.h
+++ b/src/colour.h
@@ -1,5 +1,6 @@
 /* BOLD COLOURS */
 #define BBLACK   "\033[1;30m"
+#define BGRAY    "\033[1;90m"
 #define BRED     "\033[1;31m"
 #define BGREEN   "\033[1;32m"
 #define BYELLOW  "\033[1;33m"

--- a/src/fetch.c
+++ b/src/fetch.c
@@ -394,14 +394,14 @@ void *os()
 			info.getPkgCount =
 				"dpkg -l | tail -n+6 | wc -l";
 		} else if (strncmp(osname, "void", 4) == 0) {
-			info.col1 = BGREEN "     _______\n";
-			info.col2 = BGREEN "  _ \\______ - ";
-			info.col3 = BGREEN " | \\  ___  \\ |";
-			info.col4 = BGREEN " | | /   \\ | |";
-			info.col5 = BGREEN " | | \\___/ | |";
-			info.col6 = BGREEN " | \\______ \\_|";
-			info.col7 = BGREEN "  -_______\\   ";
-			info.col8 = "";
+			info.col1 = BGREEN "      _____\n";
+			info.col2 = BGREEN "   _  \\____ -";
+			info.col3 = BGREEN "  / / ____ \\ \\";
+			info.col4 = BGREEN " / / /    \\ \\ \\";
+			info.col5 = BGREEN " | |  " BGRAY BITAL "VOID  " BGREEN "| |";
+			info.col6 = BGREEN " \\ \\ \\____/ / /";
+			info.col7 = BGREEN "  \\ \\____  /_/";
+			info.col8 = BGREEN "   -_____\\\n";
 			info.getPkgCount = "xbps-query -l | wc -l";
 		}
 


### PR DESCRIPTION
## Void's Logo
* Added 2 new ANSI codes to `colour.h`, gray and bold italics.
* Made the logo bigger, and added the distro's name in the center of the logo.

## Installation
* The `install` target requires the afetch binary to properly copy the files, so I've added `afetch` as a dependency of it.