### PR TITLE
Fixed Fetch Alignment for Void Linux

### DIFF
--- a/src/colour.h
+++ b/src/colour.h
@@ -19,4 +19,4 @@
 #define WHITE   "\033[0;37m"
 /* OTHER */
 #define RESET "\033[0;m"
-#define BITAL  "\033[1;3m" 
+#define BITAL "\033[1;3m" 

--- a/src/fetch.c
+++ b/src/fetch.c
@@ -395,16 +395,15 @@ void *os()
 				"dpkg -l | tail -n+6 | wc -l";
 		} else if (strncmp(osname, "void", 4) == 0) {
 			info.col1 = BGREEN "      _____\n";
-			info.col2 = BGREEN "   _  \\____ -";
-			info.col3 = BGREEN "  / / ____ \\ \\";
+			info.col2 = BGREEN "   _  \\____ -  ";
+			info.col3 = BGREEN "  / / ____ \\ \\ ";
 			info.col4 = BGREEN " / / /    \\ \\ \\";
 			info.col5 = BGREEN " | |  " BGRAY BITAL "VOID  " BGREEN "| |";
 			info.col6 = BGREEN " \\ \\ \\____/ / /";
-			info.col7 = BGREEN "  \\ \\____  /_/";
+			info.col7 = BGREEN "  \\ \\____  /_/ ";
 			info.col8 = BGREEN "   -_____\\\n";
 			info.getPkgCount = "xbps-query -l | wc -l";
 		}
-
 	} else if (strncmp(sysInfo.sysname, "Darwin", 6) == 0) {
 		info.col1 = "" BYELLOW;
 		info.col2 = BGREEN "          .:'   " BYELLOW;


### PR DESCRIPTION
## Alignment for Void Linux
* Added some spaces after some of the lines in the logo to align all of the fetch information.

## Indentation
* Fixed one indentation error in the `colour.h` file.