### PR TITLE
Seperated iOS and macOS

### DIFF
--- a/src/fetch.c
+++ b/src/fetch.c
@@ -413,17 +413,31 @@ void *os()
 		info.col6 = BRED "  :_________:   " BYELLOW;
 		info.col7 = BMAGENTA "   :_________`-;" BYELLOW;
 		info.col8 = BBLUE "    `.__.-.__.' " BYELLOW;
-		info.getPkgCount =
-		    "ls /usr/local/Cellar/* | grep ':' | wc -l | xargs";
+		if ((strncmp(sysInfo.machine, "iPhone", 6) == 0) || (strncmp(sysInfo.machine, "iPad", 4) == 0) || (strncmp(sysInfo.machine, "iPod", 4) == 0)) {
+			info.getPkgCount =
+		    "dpkg -l | tail -n+6 | wc -l";
 
-		char *macVer = malloc(64);
-		strcpy(macVer, "macOS ");
-		char *productVer = pipeRead("sw_vers -productVersion");
+			char *iosVer = malloc(1024);
+			strcpy(iosVer, "iOS ");
+			char *productVer = pipeRead("sw_vers -productVersion");
 
-		strcat(macVer, productVer);
-		free(productVer);
-		osname = macVer;
-		free(macVer);
+			strcat(iosVer, productVer);
+			free(productVer);
+			osname = iosVer;
+			free(iosVer);
+		} else {
+			info.getPkgCount =
+			    "ls /usr/local/Cellar/* | grep ':' | wc -l | xargs";
+
+			char *macVer = malloc(64);
+			strcpy(macVer, "macOS ");
+			char *productVer = pipeRead("sw_vers -productVersion");
+
+			strcat(macVer, productVer);
+			free(productVer);
+			osname = macVer;
+			free(macVer);
+		}
 	} else if (strncmp(sysInfo.sysname, "FreeBSD", 7) == 0) {
 		info.col1 = BRED "";
 		info.col2 = BRED "/\\,-'''''-,/\\";


### PR DESCRIPTION
iOS and macOS both returns "Darwin" when reading uname, so when running on iOS it outputs like that:
```
iPhone:~/proj/afetch mobile$ ./afetch 
ls: cannot access '/usr/local/Cellar/*': No such file or directory
          .:'          USER mobile
      __ :'__            OS macOS 14.2
   .'`__`-'__``.     KERNEL 20.1.0
  :__________.-'     UPTIME 1h 3m
  :_________:         SHELL sh
   :_________`-;       PKGS 0
    `.__.-.__.' 
```
For a jailbroken iOS device, APT is the default package manager, so I replaced getPkgCont to the same one that Debian/Ubuntu uses.
This pr fixes the issue and it will work properly on iOS devices.
```
iPhone:~/proj/afetch mobile$ ./afetch
          .:'          USER mobile
      __ :'__            OS iOS 14.2
   .'`__`-'__``.     KERNEL 20.1.0
  :__________.-'     UPTIME 1h 47m
  :_________:         SHELL sh
   :_________`-;       PKGS 675
    `.__.-.__.' 
```