### PR TITLE
close pipe before failure check, limit scanf length

### DIFF
--- a/src/fetch.c
+++ b/src/fetch.c
@@ -54,12 +54,12 @@ char *pipeRead(const char *exec)
 	if (pipe == NULL)
 		return NULL;
 	char *returnVal = malloc(256);
-	const int scanf_return = fscanf(pipe, "%[^\n]s", returnVal);
+	const int scanf_return = fscanf(pipe, "%[^\n]256s", returnVal);
+	pclose(pipe);
 	if (scanf_return == EOF) {
 		fprintf(stderr, "ERROR: scanf failed!\n");
 		exit(EXIT_FAILURE);
 	}
-	pclose(pipe);
 	return returnVal;
 }
 


### PR DESCRIPTION
close pipe before any exit condition can be reached.

if the pipes contents are longer than 255 characters it will go out of the allocated area and at best crash and at worst overwrite other memory.