### PR TITLE
Faster Fedora package fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ afetch is written in C99, meaning that it should be able to be compiled with alm
 *  Deepin
 *  Elementary OS
 *  EndeavourOS
-*  Fedora (slow due to package manager)
+*  Fedora
 *  FreeBSD
 *  Gentoo
 *  MacOS (homebrew)

--- a/src/fetch.c
+++ b/src/fetch.c
@@ -289,11 +289,7 @@ void *os()
 			info.col7 =
 				BBLUE "\\ \\" BWHITE "__/  |     " BBLUE;
 			info.col8 = BBLUE " \\" BWHITE "(_____/" BBLUE;
-			info.getPkgCount =
-				"[[ $(which sqlite3 2>/dev/null) && $? -ne "
-				"1 ]] && (sqlite3 "
-				"/var/lib/rpm/rpmdb.sqlite \"select * from "
-				"Name\"|wc -l) || rpm -qa | wc -l";
+			info.getPkgCount = "rpm -qa --nodigest --nosignature | wc -l";
 		} else if (strncmp(osname, "Gentoo", 6) == 0) {
 			info.col1 = BMAGENTA "   _-----_ \n";
 			info.col2 = BMAGENTA "  (       \\  ";


### PR DESCRIPTION
### Summary
My system has almost 3000 packages right now. 
Here is a quick comparison before and after optimising the package search by using rpm query all with skip integrity and skip signature checks:

### Original:
```
> time afetch
      _____
     /   __)\        USER shahzeb
     |  /  \ \         OS Fedora Linux
  ___|  |__/ /     KERNEL 6.16.7-200.fc42.x86_64
 / (_    _)_/      UPTIME 3h 11m
/ /  |  |           SHELL fish
\ \__/  |            PKGS 2793
 \(_____/

________________________________________________________
Executed in  569.14 millis    fish           external
   usr time  530.92 millis  734.00 micros  530.18 millis
   sys time   47.29 millis  767.00 micros   46.52 millis
```

### After changes:
```
> time ./afetch
      _____
     /   __)\        USER shahzeb
     |  /  \ \         OS Fedora Linux
  ___|  |__/ /     KERNEL 6.16.7-200.fc42.x86_64
 / (_    _)_/      UPTIME 3h 11m
/ /  |  |           SHELL fish
\ \__/  |            PKGS 2793
 \(_____/

________________________________________________________
Executed in  106.29 millis    fish           external
   usr time   75.06 millis    1.20 millis   73.86 millis
   sys time   36.18 millis    0.18 millis   35.99 millis
```